### PR TITLE
[#006] Bug fix for the lacking google api endpoints

### DIFF
--- a/.github/workflows/traffic_bot.yml
+++ b/.github/workflows/traffic_bot.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Run Traffic Script
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_ROUTES_API: ${{ secrets.GOOGLE_ROUTES_API }}
+          GOOGLE_STATIC_MAPS_API: ${{ secrets.GOOGLE_STATIC_MAPS_API }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           LAT_HOME: ${{ secrets.LAT_HOME }}
           LNG_HOME: ${{ secrets.LNG_HOME }}


### PR DESCRIPTION
This PR contains the following bug fixes:

- Fixed the issue where the google api endpoints used (routes api and static maps api) are not added in the yaml file
- Now, it is already added to the yaml file

_Note: This PR closes #11 issue, which is for the github actions bug in this bot._